### PR TITLE
Update comment from Yahoo Weather to Night Shift

### DIFF
--- a/Darkmode.sh
+++ b/Darkmode.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 ## macOS Dark Mode at sunset
-## Solar times pulled from Yahoo Weather API
+## Solar times pulled from Night Shift
 ## Author: katernet ## Version 1.8.1
 
 ## Global variables ##


### PR DESCRIPTION
With Yahoo Weather having been removed and the readme already updated to reflect that, Yahoo is still referenced in the top of the script in a comment. Remove this last reference to Yahoo Weather and replace it with Night Shift, to avoid future people like me being confused as to where Yahoo is involved!